### PR TITLE
Beans-zero dependency now using https for git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ torchaudio = [
   { index = "pytorch-cpu", marker = "platform_system == 'Darwin'" },
   { index = "pytorch-cu118", marker = "platform_system == 'Linux'" },
 ]
-beans-zero = { git = "ssh://git@github.com/earthspecies/beans-zero.git" }
+beans-zero = { git = "https://git@github.com/earthspecies/beans-zero.git" }
 
 [tool.ruff]
 line-length = 120

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ async-timeout==5.0.1 ; python_full_version < '3.11'
 attrs==23.2.0
 audioop-lts==0.2.1 ; python_full_version >= '3.13'
 audioread==3.0.1
-beans-zero @ git+ssh://git@github.com/earthspecies/beans-zero.git@257bb64e7beaaadc1c85a0e5871534be3193ddc0
+beans-zero @ git+https://git@github.com/earthspecies/beans-zero.git@v1.0.0
 bitsandbytes==0.43.1
 bleach==6.2.0
 cachetools==5.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,21 +13,22 @@ async-timeout==5.0.1 ; python_full_version < '3.11'
 attrs==23.2.0
 audioop-lts==0.2.1 ; python_full_version >= '3.13'
 audioread==3.0.1
-beans-zero @ git+https://git@github.com/earthspecies/beans-zero.git@v1.0.0
+beans-zero @ git+https://github.com/earthspecies/beans-zero.git@31d4487ee6452ae6c31853d45fd38b7d4150372d
 bitsandbytes==0.43.1
-bleach==6.2.0
 cachetools==5.5.0
 certifi==2024.6.2
 cffi==1.16.0
+cfgv==3.4.0
 charset-normalizer==3.3.2
 click==8.1.8
 cloudpathlib==0.20.0
-colorama==0.4.6 ; sys_platform == 'win32' or platform_system == 'Windows'
+colorama==0.4.6 ; sys_platform == 'win32'
 contourpy==1.2.1
 cycler==0.12.1
 datasets==3.5.0
 decorator==5.1.1
 dill==0.3.8
+distlib==0.3.9
 docker-pycreds==0.4.0
 docstring-parser==0.16
 einops==0.8.0
@@ -62,11 +63,11 @@ h11==0.14.0
 httpcore==1.0.5
 httpx==0.27.0
 huggingface-hub==0.29.1
+identify==2.6.3
 idna==3.7
 iniconfig==2.0.0
 jinja2==3.1.4
 joblib==1.4.2
-kaggle==1.6.17
 kiwisolver==1.4.5
 levenshtein==0.27.1
 librosa==0.9.2
@@ -83,20 +84,20 @@ multidict==6.1.0
 multiprocess==0.70.16
 networkx==3.3
 ninja==1.11.1.1
+nodeenv==1.9.1
 numba==0.60.0
 numpy==1.26.4
-nvidia-cublas-cu11==11.11.3.6 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-nvidia-cuda-cupti-cu11==11.8.87 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-nvidia-cuda-nvrtc-cu11==11.8.89 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-nvidia-cuda-runtime-cu11==11.8.89 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-nvidia-cudnn-cu11==8.7.0.84 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-nvidia-cufft-cu11==10.9.0.58 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-nvidia-curand-cu11==10.3.0.86 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-nvidia-cusolver-cu11==11.4.1.48 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-nvidia-cusparse-cu11==11.7.5.86 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-nvidia-nccl-cu11==2.19.3 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-nvidia-nccl-cu12==2.25.1 ; platform_machine != 'aarch64' and platform_system == 'Linux'
-nvidia-nvtx-cu11==11.8.86 ; platform_machine == 'x86_64' and platform_system == 'Linux'
+nvidia-cublas-cu11==11.11.3.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cuda-cupti-cu11==11.8.87 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cuda-nvrtc-cu11==11.8.89 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cuda-runtime-cu11==11.8.89 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cudnn-cu11==8.7.0.84 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cufft-cu11==10.9.0.58 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-curand-cu11==10.3.0.86 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cusolver-cu11==11.4.1.48 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cusparse-cu11==11.7.5.86 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-nccl-cu11==2.19.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-nvtx-cu11==11.8.86 ; platform_machine == 'x86_64' and sys_platform == 'linux'
 orjson==3.10.5
 packaging==24.1
 pandas==1.4.3
@@ -106,6 +107,7 @@ platformdirs==4.2.2
 pluggy==1.5.0
 plumbum==1.7.2
 pooch==1.8.2
+pre-commit==4.0.1
 propcache==0.2.1
 proto-plus==1.25.0
 protobuf==5.27.2
@@ -113,8 +115,6 @@ psutil==6.0.0
 pyarrow==19.0.0
 pyasn1==0.6.1
 pyasn1-modules==0.4.1
-pycocoevalcap==1.2
-pycocotools==2.0.8
 pycparser==2.22
 pydantic==2.7.4
 pydantic-core==2.18.4
@@ -126,9 +126,8 @@ pytest==8.3.5
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 python-multipart==0.0.20
-python-slugify==8.0.4
 pytz==2024.1
-pywin32==308 ; platform_python_implementation != 'PyPy' and platform_system == 'Windows'
+pywin32==308 ; platform_python_implementation != 'PyPy' and sys_platform == 'win32'
 pyyaml==6.0
 rapidfuzz==3.9.4
 regex==2024.5.15
@@ -136,7 +135,7 @@ requests==2.32.3
 resampy==0.3.1
 rich==14.0.0
 rsa==4.9
-ruff==0.9.9 ; sys_platform != 'emscripten'
+ruff==0.9.9
 safehttpx==0.1.6
 safetensors==0.4.3
 scikit-learn==1.1.1
@@ -157,31 +156,29 @@ sympy==1.12.1
 tensorboard==2.18.0
 tensorboard-data-server==0.7.2
 tensorboardx==2.6.2.2
-text-unidecode==1.3
 threadpoolctl==3.5.0
 tokenizers==0.19.1
 tomli==2.0.1 ; python_full_version < '3.11'
 tomlkit==0.12.0
-torch==2.2.2 ; platform_system == 'Darwin'
-torch==2.2.2 ; platform_system != 'Darwin' and platform_system != 'Linux'
-torch==2.2.2+cu118 ; platform_system == 'Linux'
-torchaudio==2.2.2 ; platform_system == 'Darwin'
-torchaudio==2.2.2 ; platform_system != 'Darwin' and platform_system != 'Linux'
-torchaudio==2.2.2+cu118 ; platform_system == 'Linux'
-torchvision==0.17.2 ; platform_system == 'Darwin'
-torchvision==0.17.2 ; platform_system != 'Darwin' and platform_system != 'Linux'
-torchvision==0.17.2+cu118 ; platform_system == 'Linux'
+torch==2.2.2 ; sys_platform == 'darwin'
+torch==2.2.2 ; sys_platform != 'darwin' and sys_platform != 'linux'
+torch==2.2.2+cu118 ; sys_platform == 'linux'
+torchaudio==2.2.2 ; sys_platform == 'darwin'
+torchaudio==2.2.2 ; sys_platform != 'darwin' and sys_platform != 'linux'
+torchaudio==2.2.2+cu118 ; sys_platform == 'linux'
+torchvision==0.17.2 ; sys_platform == 'darwin'
+torchvision==0.17.2 ; sys_platform != 'darwin' and sys_platform != 'linux'
+torchvision==0.17.2+cu118 ; sys_platform == 'linux'
 tqdm==4.66.4
 transformers==4.44.2
-triton==2.2.0 ; python_full_version < '3.12' and platform_machine == 'x86_64' and platform_system == 'Linux'
+triton==2.2.0 ; python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'
 typer==0.12.3 ; sys_platform != 'emscripten'
 typing-extensions==4.12.2
 urllib3==2.2.2
 uvicorn==0.30.1 ; sys_platform != 'emscripten'
+virtualenv==20.28.0
 wandb==0.17.3
-webencodings==0.5.1
 websockets==12.0
 werkzeug==3.1.3
-xgboost==2.1.4
 xxhash==3.5.0
 yarl==1.18.3

--- a/uv.lock
+++ b/uv.lock
@@ -245,8 +245,8 @@ wheels = [
 
 [[package]]
 name = "beans-zero"
-version = "0.1.0"
-source = { git = "ssh://git@github.com/earthspecies/beans-zero.git#040b0e594307c1ad1f1e8214691cd2ae622fb482" }
+version = "1.0.0"
+source = { git = "https://github.com/earthspecies/beans-zero.git#31d4487ee6452ae6c31853d45fd38b7d4150372d" }
 dependencies = [
     { name = "click" },
     { name = "datasets" },
@@ -1656,7 +1656,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "beans-zero", git = "ssh://git@github.com/earthspecies/beans-zero.git" },
+    { name = "beans-zero", git = "https://github.com/earthspecies/beans-zero.git" },
     { name = "bitsandbytes", specifier = ">=0.43.1" },
     { name = "click", specifier = ">=8.1.7" },
     { name = "cloudpathlib", extras = ["gs"], specifier = ">=0.20.0" },


### PR DESCRIPTION
Installing Naturelm-audio with the beans-zero dependency currently doesn't work for users / pipelines without ssh keys. This PR switches the dependency to use https with git.